### PR TITLE
Typo fix on ca1305 page

### DIFF
--- a/docs/code-quality/ca1305.md
+++ b/docs/code-quality/ca1305.md
@@ -66,7 +66,7 @@ ms.locfileid: "84182187"
 
 ## <a name="example"></a>Пример
 
-В следующем коде `example1` строка нарушает правило CA1305. `example2`Строка удовлетворяет правилу CA1305 путем передачи <xref:System.Globalization.CultureInfo.CurrentCulture%2A?displayProperty=nameWithType> , которая реализует <xref:System.IFormatProvider> , в <xref:System.String.Format(System.IFormatProvider,System.String,System.Object)?displayProperty=nameWithType> . `example3`Строка удовлетворяет правилу CA1305, передавая строку с интерполяцией в <xref:System.FormattableString.Invariant%2A?displayProperty=fullName]> .
+В следующем коде `example1` строка нарушает правило CA1305. `example2` строка удовлетворяет правилу CA1305 путем передачи <xref:System.Globalization.CultureInfo.CurrentCulture%2A?displayProperty=nameWithType>, которая реализует <xref:System.IFormatProvider>, в <xref:System.String.Format(System.IFormatProvider,System.String,System.Object)?displayProperty=nameWithType>. `example3` строка удовлетворяет правилу CA1305, передавая строку с интерполяцией в <xref:System.FormattableString.Invariant%2A?displayProperty=fullName]>.
 
 ```csharp
 string name = "Georgette";


### PR DESCRIPTION
Added space between symbol "'" and "string" word. 
Removed space between a word and ".", "," symbols
